### PR TITLE
SCAN: Increase error page's time to await results

### DIFF
--- a/app/templates/scan/error.html
+++ b/app/templates/scan/error.html
@@ -12,7 +12,7 @@
         The date of birth must be entered for the participant who was tested.
       </p>
       <p>
-        <span class='font-weight-bold'>Note: Recently collected tests may not yet be available in SecureLink. Please check 12-24 hours after collection.</span>
+        <span class='font-weight-bold'>Note: Recently collected tests may not yet be available in SecureLink. Please check 2-3 days after collection.</span>
       </p>
       <hr/>
 


### PR DESCRIPTION
Change the Error page template to tell participants to check back in 2-3
days to match how long it is taking to unbox and log samples.