### PR TITLE
SCAN: Update pending time to 2-3 days

### DIFF
--- a/app/templates/scan/results.html
+++ b/app/templates/scan/results.html
@@ -58,8 +58,8 @@
                   {% elif result.status_code == "pending" %}
                     <span>
                       Result pending. Awaiting laboratory results. Most
-                      COVID-19 test results will be available within 10–12 days
-                      of sample collection.
+                      COVID-19 test results will be available 2–3 days after
+                      the sample is received at the lab.
 
                   {% elif result.status_code == "never-tested" %}
                     <span>Sample could not be tested.


### PR DESCRIPTION
We're now able to return results in 2-3 days. Update the `pending`
result status text to reflect this.