### PR TITLE
SCAN: Tweak the language on the error page

### DIFF
--- a/app/templates/scan/error.html
+++ b/app/templates/scan/error.html
@@ -10,7 +10,8 @@
       <p>
         If it’s been longer than 3 days, please make sure you’re typing in the
         barcode on your swab tube or swab kit box exactly as shown.  The date
-        of birth must be entered for the participant who was tested.
+        of birth should be the same as what you entered when you enrolled in
+        SCAN.
       </p>
       <p>
         <b><a href="/scan">&lt;&lt; Click here to go back and try again.</a></b>

--- a/app/templates/scan/error.html
+++ b/app/templates/scan/error.html
@@ -2,17 +2,18 @@
 {% block content %}
      <div class="col-lg-9">
 
-      <h3 style="color: darkred">Sample not yet received or no matching records found</h3>
-      <hr/>
+      <h4>Swab not yet received or no matching records found.</h4>
+      <p>
+        If you recently returned your swab, please check back later.  Most
+        swabs are received within 3 days.
+      </p>
+      <p>
+        If it’s been longer than 3 days, please make sure you’re typing in the
+        barcode on your swab tube or swab kit box exactly as shown.  The date
+        of birth must be entered for the participant who was tested.
+      </p>
       <p>
         <b><a href="#" onclick="history.go(-1)">&lt;&lt; Click here to go back and try again.</a></b>
-      </p>
-      <p>
-        Please type in the barcode on your swab tube or swab kit box exactly as shown.
-        The date of birth must be entered for the participant who was tested.
-      </p>
-      <p>
-        <span class='font-weight-bold'>Note: Recently collected tests may not yet be available in SecureLink. Please check 2-3 days after collection.</span>
       </p>
       <hr/>
 

--- a/app/templates/scan/error.html
+++ b/app/templates/scan/error.html
@@ -13,7 +13,7 @@
         of birth must be entered for the participant who was tested.
       </p>
       <p>
-        <b><a href="#" onclick="history.go(-1)">&lt;&lt; Click here to go back and try again.</a></b>
+        <b><a href="/scan">&lt;&lt; Click here to go back and try again.</a></b>
       </p>
       <hr/>
 

--- a/app/templates/scan/results.html
+++ b/app/templates/scan/results.html
@@ -20,7 +20,7 @@
 
 {% block content %}
      <div class="col-lg-10">
-      <p><a href="#" onclick="history.go(-1)">&lt;&lt; Retrieve another result</a></p>
+      <p><a href="/scan">&lt;&lt; Retrieve another result</a></p>
 
         <div id="result-card">
           <div class="table-responsive">


### PR DESCRIPTION
To further distinguish between not yet received and no matching records.
I was looking at this because we might effectively stop using our
not-received status, which would land more people here.

---

### Before
![Screenshot from 2020-04-06 14-58-25](https://user-images.githubusercontent.com/79913/78612764-fef45980-781e-11ea-8328-ab4a96e9f3cd.png)

### After
![Screenshot from 2020-04-06 14-46-26](https://user-images.githubusercontent.com/79913/78612770-01ef4a00-781f-11ea-8317-7972e11f911b.png)
