### PR TITLE
Change "Collection Date" to "Enrollment Date"

### DIFF
--- a/app/templates/scan/results.html
+++ b/app/templates/scan/results.html
@@ -29,7 +29,7 @@
               <tr>
                 <th class='w-25'>Name <br/><span style="font-size: 10pt">(Date of Birth)</span></th>
                 <th>Test Result</th>
-                <th>Collected Date</th>
+                <th>Enrollment Date</th>
                 <th>Barcode</th>
               </tr>
             </thead>


### PR DESCRIPTION
The actual REDCap field we're pulling these data from is called
"enrollment_date." Update the language on our page to actually match
our data model while also reducing potential SCAN participant confusion.