### PR TITLE
SCAN: Turn off RoR portal

### DIFF
--- a/app/templates/scan/index.html
+++ b/app/templates/scan/index.html
@@ -3,99 +3,18 @@
      <div class="col-lg-9">
         <h4>Welcome to the <b>SCAN SecureLink results portal.</b></h4>
         <p class="lead">
-          If you are part of the SCAN study and were tested for the SARS-CoV-2 (COVID-19) Virus, you can use this portal to retrieve the status and/or results of your testing.
-          Please enter the 8-character barcode of your sample and your date of birth below.
+          Thank you for your participation in the Seattle Coronavirus Assessment
+          Network (SCAN). Our testing of home-based, self-collected samples for
+          COVID-19 is currently paused, and retrieval of results is temporarily
+          suspended.  Please see our
+          <a href="https://scanpublichealth.org/updates/2020-05-13">
+            full update on the SCAN website</a>.
         </p>
         <p>
-          <b>If you are a UW Medicine patient, Emergency Responder, or received your test via UW Medicine, <a href='/'>please use this link to retrieve your result</a>.</b>
+          If the link above does not work, try copying the following link into
+          your web browser:
+          <a href="https://scanpublichealth.org/updates/2020-05-13">
+            https://scanpublichealth.org/updates/2020-05-13</a>
         </p>
-        <div class='row'>
-          <div class='col-lg-10'>
-            <div id="form-card">
-              <form action="/scan/result" method="post" id="submitform">
-                <div class="form-group col-md-12">
-                  <label for="barcode">Sample Barcode <a id="showexample" href="#">(Where can I find this?)</a></label>
-                  <div id="example">
-                    Your sample's unique barcode is an 8-character code which
-                    can be found on both your swab tube and swab kit box.
-                    <img src="/static/img/scan-example.jpg" class="m-3 img-fluid rounded" />
-                  </div>
-                  <input class="form-control"
-                      id='barcode'
-                      name="barcode"
-                      aria-describedby="barcode"
-                      placeholder="########"
-                      value="{{ barcode }}"
-                      type="text"
-                      style="text-transform:uppercase"
-                      autocomplete="off"
-                  />
-                  <small id="barcodeHelp" class="form-text text-muted">8-character barcode from your swab tube or swab kit box</small>
-                </div>
-                <div class="form-group col-md-6">
-                  <label for="dob">Date of Birth</label>
-                  <input class="form-control"
-                    id='dob'
-                    name="dob"
-                    aria-describedby="dob"
-                    placeholder="MM/DD/YYYY"
-                    autocomplete="off"
-                  / >
-                  <small id="barcodeHelp" class="form-text text-muted">Your date of birth</small>
-                </div>
-                <div class="form-group col-md-12">
-                  <button type="submit" class="btn btn-secondary float-right">Click here to retrieve results</button>
-                </div>
-              </form>
-            </div>
-          </div>
-
-        </div>
-          <div class='row'>
-            <div class='col-lg-10'>
-              <div class='card card-body bg-light'>
-                  <p><span class='font-weight-bold'>If you have lost your barcode or you cannot access the status of your test</span>, please email <a href="mailto:support@scanpublichealth.org?subject=Retrieving%20my%20results">support@scanpublichealth.org</a> or call <a href="tel:+1-206-616-5859">(206) 616-5859</a>. Please do <b>not</b> call if your test is shown as "pending".</p>
-              </div>
-          </div>
-        <script>
-        $(document).ready(
-          $("#showexample").click(function () {
-              $("#example").toggle();
-          })
-        );
-
-
-        $("#barcode").mask("AAAAAAAA")
-        $("#dob").mask("00/00/0000")
-        jQuery.validator.addMethod("validBarcode", function(value) {
-            return value.match(/^([A-Fa-f0-9]{8})$/g)
-        }, "Please enter an 8-digit barcode containing only the number 0-9 and letters A-F.");
-
-
-        jQuery.validator.addMethod("validDob", function(value) {
-            return value.match(/([0-9]{2})\/([0-9]{2})\/(19|20[0-9]{2})/g)
-        }, "Please enter a valid date of birth.");
-
-
-        $("#submitform").validate({
-          rules: {
-            barcode: {
-              validBarcode: true
-            },
-            dob: {
-              validDob: true
-            }
-          },
-          messages: {
-            barcode: {
-              required: "Please enter the 8-character barcode.",
-              minlength: "Barcode must be 8 characters. Please omit any dashes."
-            },
-            dob: {
-              required: "Please enter date in MM/DD/YYYY format."
-            }
-          }
-        });
-        </script>
       </div>
 {% endblock %}


### PR DESCRIPTION
Turn off the return of results (RoR) portal since the FDA shut down SCAN
for the time being. Update the SCAN landing page with a message about
why we are shut down. Remove the `/scan/result` and `/scan/pdfreport`
endpoints to prevent returning of results. Also remove the now unused
`/scan/error` endpoint.

-----------------------------

Before you merge this @nkrumm, I'd like to ask @tsibley to take a look to make sure that I've shut down everything on the SCAN side appropriately. 